### PR TITLE
Clarified View, Serializer names. Added more routes.

### DIFF
--- a/sg_backend/serializers.py
+++ b/sg_backend/serializers.py
@@ -4,39 +4,23 @@ from django.contrib.auth.models import User
 from .models import Categories, Topics, Notes
 
 
-class CategoriesListSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Categories
-        exclude = ['user', ]
-
-
+# Notes
 class NotesListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notes
         exclude = ['topic', ]
 
 
-# class TopicsListSerializer(serializers.ModelSerializer):
-#
-#     class Meta:
-#         model = Topics
-#         exclude = ['category', ]
-#
-#
-# class CategoryDetailsWithTopicsSerializer(serializers.ModelSerializer):
-#       """
-#       A Category's detail with related topics at depth 1.
-#       """
-#     topics = TopicsListSerializer(source='topics_set', many=True)
-#
-#     class Meta:
-#         model = Categories
-#         exclude = ['user']
+# Topics
+class TopicsListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Topics
+        exclude = ['category', ]
 
 
-class TopicsWithNotesSerializer(serializers.ModelSerializer):
+class TopicsListWithNotesSerializer(serializers.ModelSerializer):
     """
-    Gets the related notes to this topic.
+    List of all Topics with related notes.
     """
     notes = NotesListSerializer(source='notes_set', many=True)
 
@@ -45,17 +29,47 @@ class TopicsWithNotesSerializer(serializers.ModelSerializer):
         fields = ['id', 'topic_name', 'notes']
 
 
-class CategoryWithTopicsSerializer(serializers.ModelSerializer):
+class TopicDetailsWithNotesSerializer(serializers.ModelSerializer):
     """
-    Gets the related topics to this category.
+    A topic's details and its related notes.
     """
-    topics = TopicsWithNotesSerializer(source='topics_set', many=True)
+    notes = NotesListSerializer(source='notes_set', many=True)
+
+    class Meta:
+        model = Topics
+        fields = ['id', 'topic_name', 'notes']
+
+
+# Categories
+class CategoriesListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Categories
+        exclude = ['user', ]
+
+
+class CategoryDetailsWithTopicsOnlySerializer(serializers.ModelSerializer):
+    """
+    A Category's detail with related topics at depth 1.
+    """
+    topics = TopicsListSerializer(source='topics_set', many=True)
 
     class Meta:
         model = Categories
         fields = ['id', 'category_name', 'category_desc', 'topics']
 
 
+class CategoryWithTopicsSerializer(serializers.ModelSerializer):
+    """
+    Gets the related topics to this category.
+    """
+    topics = TopicsListWithNotesSerializer(source='topics_set', many=True)
+
+    class Meta:
+        model = Categories
+        fields = ['id', 'category_name', 'category_desc', 'topics']
+
+
+# Users
 class UsersListSerializer(serializers.ModelSerializer):
     """
     Displays all Users

--- a/sg_backend/urls.py
+++ b/sg_backend/urls.py
@@ -1,16 +1,23 @@
-from django.urls import path
+from django.urls import path, re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
 
 
 urlpatterns = [
-    path('categories/', views.AllCategoriesListView.as_view()),
     path('users/', views.AllUsersListView.as_view()),
     path('user/<int:pk>/', views.UserDetailsView.as_view()),
     path('user/<int:pk>/all/', views.UserDetailWithAllDataView.as_view()),
     path('user/<int:pk>/categories/', views.UserDetailsCategoriesView.as_view()),
-    # path('user/<int:pk>/categories/<int:cid>/', views.CategoryDetailsWithTopicsView.as_view())
+
+    path('categories/', views.AllCategoriesListView.as_view()),
+    path('category/<int:pk>/', views.CategoryDetailsWithTopicsView.as_view()),
+
+    path('topics/', views.AllTopicsListView.as_view()),
+    path('topic/<int:pk>/', views.TopicDetailsWithNotesView.as_view()),
+
+    path('notes/', views.AllNotesListView.as_view()),
+    path('note/<int:pk>/', views.NoteDetailsView.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/sg_backend/views.py
+++ b/sg_backend/views.py
@@ -1,31 +1,58 @@
 from rest_framework import generics
 from django.contrib.auth.models import User
 
-from sg_backend.models import Categories
-from sg_backend.serializers import UsersListSerializer, UserDetailSerializer, UserDetailWithAllData, CategoriesListSerializer, UserCategoryDetails, CategoryWithTopicsSerializer
+from sg_backend.models import Categories, Topics, Notes
+from . import serializers
 
-
+# User based views
 class AllUsersListView(generics.ListAPIView):
-    serializer_class = UsersListSerializer
+    serializer_class = serializers.UsersListSerializer
     queryset = User.objects.all()
 
 
 class UserDetailsView(generics.RetrieveAPIView):
-    serializer_class = UserDetailSerializer
+    serializer_class = serializers.UserDetailSerializer
     queryset = User.objects.all()
 
 
 class UserDetailWithAllDataView(generics.RetrieveAPIView):
-    serializer_class = UserDetailWithAllData
+    serializer_class = serializers.UserDetailWithAllData
     queryset = User.objects.all()
-
-
-class AllCategoriesListView(generics.ListAPIView):
-    serializer_class = CategoriesListSerializer
-    queryset = Categories.objects.all()
 
 
 class UserDetailsCategoriesView(generics.RetrieveAPIView):
-    serializer_class = UserCategoryDetails
+    serializer_class = serializers.UserCategoryDetails
     queryset = User.objects.all()
 
+
+# Categories based views
+class AllCategoriesListView(generics.ListAPIView):
+    serializer_class = serializers.CategoriesListSerializer
+    queryset = Categories.objects.all()
+
+
+class CategoryDetailsWithTopicsView(generics.RetrieveAPIView):
+    serializer_class = serializers.CategoryDetailsWithTopicsOnlySerializer
+    queryset = Categories.objects.all()
+
+
+# Topics based views
+class AllTopicsListView(generics.ListAPIView):
+    serializer_class = serializers.TopicsListSerializer
+    queryset = Topics.objects.all()
+
+
+class TopicDetailsWithNotesView(generics.RetrieveAPIView):
+    serializer_class = serializers.TopicsListWithNotesSerializer
+    queryset = Topics.objects.all()
+
+
+# Notes based views
+class AllNotesListView(generics.ListAPIView):
+    serializer_class = serializers.NotesListSerializer
+    queryset = Notes.objects.all()
+
+
+class NoteDetailsView(generics.RetrieveAPIView):
+    serializer_class = serializers.NotesListSerializer
+    queryset = Notes.objects.all()


### PR DESCRIPTION
Example usage:
/user/<id>/categories/: list all categories belonging to user id

When user taps on category id 4, take the category id and pass it to the next route to get the category's detail: /category/<id>/

Repeat for Topics and Notes