### PR TITLE
getUserInfo should no longer be called without userId.

### DIFF
--- a/frontend/src/components/common/PrivateRoute.js
+++ b/frontend/src/components/common/PrivateRoute.js
@@ -6,13 +6,15 @@ import { LOGIN } from '../../routes/routes';
 
 
 const ConnectedPrivateRoute = ({ component: Component, user, ...rest }) => {
+    const { isLoading, isAuthenticated, username, userId } = user;
+
     return (
         <Route
             {...rest}
             render={(props) => {
-                if (user.isLoading) {
+                if (isLoading || isAuthenticated && !userId) {
                     return <div>Loading...</div>;
-                } else if (!user.isAuthenticated) {
+                } else if (!isAuthenticated) {
                     return <Redirect to={LOGIN} />;
                 } else {
                     return <Component {...props} />

--- a/frontend/src/components/endpoints/authEndpoints.js
+++ b/frontend/src/components/endpoints/authEndpoints.js
@@ -3,7 +3,6 @@ import getCookie from './getCookie';
 
 
 
-
 const userLogin = (formData) => {
     const csrfToken = getCookie('csrftoken');
 

--- a/frontend/src/reducers/authReducers.js
+++ b/frontend/src/reducers/authReducers.js
@@ -37,7 +37,8 @@ const authReducers = (state=initialState, action) => {
                 userId,
                 username,
                 isAdmin,
-                isLoading: false
+                isLoading: false,
+                isAuthenticated: true,
             };
 
         }


### PR DESCRIPTION
-when browser refreshes, token exists but initial user state is defaulted to null.
-PrivateRoute allows Component to be loaded when user is not loading. Changed this so that the userId is required before continuing the auth process flow.