### PR TITLE
Display register form errors

### DIFF
--- a/frontend/src/actions/registerActions.js
+++ b/frontend/src/actions/registerActions.js
@@ -15,7 +15,7 @@ const registerUser = (formData) => {
                 return response;
             }
 
-            dispatch(userRegisterFail());
+            dispatch(userRegisterFail(response));
             return response;
         })
         .then(resp => {
@@ -47,9 +47,10 @@ const userRegisterSuccess = (payload) => {
     }
 };
 
-const userRegisterFail = () => {
+const userRegisterFail = (payload) => {
     return {
-        type: REGISTER_FAIL
+        type: REGISTER_FAIL,
+        payload
     };
 };
 

--- a/frontend/src/components/auth/RegistrationForm.js
+++ b/frontend/src/components/auth/RegistrationForm.js
@@ -20,11 +20,20 @@ class ConnectedRegistrationForm extends Component {
             email: '',
             username: '',
             password: '',
-            confirmPassword: ''
+            confirmPassword: '',
+            errors: this.props.registrationErrors
         };
 
         this.handleInput = this.handleInput.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.registrationErrors !== this.props.registrationErrors) {
+            this.setState({
+                errors: this.props.registrationErrors
+            });
+        }
     }
 
     handleInput(e) {
@@ -36,7 +45,7 @@ class ConnectedRegistrationForm extends Component {
     handleSubmit(e) {
         e.preventDefault();
 
-        const { password, confirmPassword } = this.state;
+        const { password, confirmPassword, errors } = this.state;
 
         if (password === confirmPassword) {
             const { email, username, password} = this.state;
@@ -55,19 +64,37 @@ class ConnectedRegistrationForm extends Component {
                 password: '',
                 confirmPassword: '',
             });
+        } else {
+            const mismatchErrors = {
+                ...errors,
+                password: ['This field does not match.'],
+                confirmPassword: ['This field does not match.']
+            }
+            this.setState({
+                errors: {...mismatchErrors}
+            });
         }
     }
 
     render() {
+        const { errors } = this.state;
+
         const fieldsWithHandler = Object.entries(formFields).map(item => {
             const key = item[0];
             const value = item[1];
 
             if (key in this.state) {
+                let errorName = null;
+                if (errors && key in errors) {
+                    console.log('this.state.errors: ', errors)
+                    errorName = errors[key].toString();
+                }
+
                 return {
                     ...value,
                     value: this.state[key],
-                    onChange: this.handleInput
+                    onChange: this.handleInput,
+                    fieldError: errorName
                 };
             }
         });
@@ -87,10 +114,11 @@ class ConnectedRegistrationForm extends Component {
 
 
 const mapStateToProps = (state) => {
-    const { isAuthenticated } = state.user;
+    const { isAuthenticated, registrationErrors } = state.user;
     return {
-        isAuthenticated
-    }
+        isAuthenticated,
+        registrationErrors
+    };
 };
 
 const RegistrationForm = connect(mapStateToProps, { registerUser })(ConnectedRegistrationForm);

--- a/frontend/src/components/endpoints/authEndpoints.js
+++ b/frontend/src/components/endpoints/authEndpoints.js
@@ -96,17 +96,7 @@ const userRegister = (formData) => {
         headers
     })
     .then(response => {
-        const { status, statusText } = response;
-
-        if (status === 200) {
-            return response.json()
-        }
-
-        return {
-            response,
-            status,
-            error: statusText
-        }
+        return response.json();
     })
     .catch(error => {
         return error;

--- a/frontend/src/reducers/authReducers.js
+++ b/frontend/src/reducers/authReducers.js
@@ -17,7 +17,8 @@ let initialState = {
     isAdmin: false,
     token: localStorage.getItem('token'),
     isLoading: false,
-    authErrors: null
+    authErrors: null,
+    registrationErrors: null
 };
 
 
@@ -53,6 +54,7 @@ const authReducers = (state=initialState, action) => {
                 isLoading: false,
                 token: action.payload,
                 authErrors: null,
+                registrationErrors: null
             };
         }
 
@@ -62,10 +64,18 @@ const authReducers = (state=initialState, action) => {
             return {
                 ...state,
                 authErrors: {...errors}
-            }
+            };
         }
 
-        case REGISTER_FAIL: 
+        case REGISTER_FAIL: {
+            // localStorage.removeItem('token');
+            const { errors } = action.payload;
+            return {
+                ...state,
+                registrationErrors: {...errors}
+            };
+        }
+
         case LOGOUT_SUCCESS: {
             localStorage.removeItem('token');
             return {
@@ -77,7 +87,7 @@ const authReducers = (state=initialState, action) => {
                 token: null,
                 isLoading: false,
                 authErrors: null
-            }
+            };
         }
 
         default:

--- a/sg_auth/serializers.py
+++ b/sg_auth/serializers.py
@@ -10,7 +10,10 @@ class RegisterUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'email', 'username', 'password')
-        extra_kwargs = {'password': {'write_only': True}}
+        extra_kwargs = {
+          'password': {'write_only': True},
+          'email': {'required': True, 'allow_blank': False}
+        }
 
 
     def create(self, validated_data):

--- a/sg_auth/views.py
+++ b/sg_auth/views.py
@@ -26,7 +26,9 @@ class RegistrationAPIView(generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+
+        if not serializer.is_valid():
+            return Response({'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         user = serializer.save()
 


### PR DESCRIPTION
-default django does not require email to create new users, so extra_kwargs now requires email to be required.
-added new state for handling registration errors.
-password mismatch errors will override password "field is blank" errors if the two fields are mismatched.